### PR TITLE
Added terms of use related requests/responses

### DIFF
--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -35,7 +35,7 @@
       <HintPath>..\..\third_party\DotNetZipLib-DevKit-v1.9\zip-v1.9\Release\Ionic.Zip.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp">
-      <HintPath>..\..\third_party\RestSharp\RestSharp\bin\Debug\RestSharp.dll</HintPath>
+      <HintPath>..\..\third_party\RestSharp\RestSharp\bin\$(Configuration)\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -58,6 +58,7 @@
     <Compile Include="Requests\Search.cs" />
     <Compile Include="Requests\JSONRequest.cs" />
     <Compile Include="Requests\PackageDownload.cs" />
+    <Compile Include="Requests\TermsOfUse.cs" />
     <Compile Include="Requests\Undeprecate.cs" />
     <Compile Include="Requests\Upvote.cs" />
     <Compile Include="Utility\FileUtilities.cs" />

--- a/src/GregClient/Requests/TermsOfUse.cs
+++ b/src/GregClient/Requests/TermsOfUse.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RestSharp;
+
+namespace Greg.Requests
+{
+    public class TermsOfUse : Request
+    {
+        private readonly Method httpMethod = Method.GET;
+
+        public TermsOfUse(bool queryAcceptanceStatus)
+        {
+            httpMethod = queryAcceptanceStatus ? Method.GET : Method.PUT;
+        }
+
+        public override string Path
+        {
+            get { return "tou"; }
+        }
+
+        public override Method HttpMethod
+        {
+            get { return httpMethod; }
+        }
+
+        internal override void Build(ref RestRequest request)
+        {
+        }
+    }
+}

--- a/src/GregClient/Responses/Responses.cs
+++ b/src/GregClient/Responses/Responses.cs
@@ -84,6 +84,12 @@ namespace Greg.Responses
         public string _id { get; set; }
     }
 
+    public class TermsOfUseStatus
+    {
+        public string user_id { get; set; }
+        public Boolean accepted { get; set; }
+    }
+
     public class Comment
     {
         public string text { get; set; }

--- a/src/GregClientSandbox/GregClientSandbox.csproj
+++ b/src/GregClientSandbox/GregClientSandbox.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\..\..\..\..\..\Desktop\DotNetOpenAuth-4.2.2.13055\Lib\log4net.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp">
-      <HintPath>..\..\third_party\RestSharp\RestSharp\bin\Debug\RestSharp.dll</HintPath>
+      <HintPath>..\..\third_party\RestSharp\RestSharp\bin\$(Configuration)\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Background
-----
This is the .NET client counterpart of [the *Terms of Use* web APIs](https://github.com/DynamoDS/GReg/pull/1). It will be consumed by DynamoCore to determine if a given publisher has accepted the terms of use prior to publishing a new package.

Hi @pboyer, please have a look at this while we [add more code](https://github.com/DynamoDS/Dynamo/pull/4254) to make use of this .NET client in DynamoCore. Do I miss anything here? It feels too small an implementation. Thanks!