### PR TITLE
Implemented client-side APIs to ban/unban packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ GRegClient is a client for the GReg package manager written in C#.  You can find
 
 * magically find all of the dependencies your package has (that's up to you)
 * provide Autodesk 360 login credentials
+
+#### Steps to build GRegClientNET solution:
+
+1. Navigate to `GRegClientNET\third_party\RestSharp` folder
+2. Build `RestSharp.sln` solution (both `Debug` and `Release` configurations)
+3. Build `GRegClientNET\src\GregClient.sln` solution
+
+Note: Step 1 and 2 are only done once after cloning the repo for the first time

--- a/src/GregClient/GregClient.csproj
+++ b/src/GregClient/GregClient.csproj
@@ -50,6 +50,7 @@
     <Compile Include="AuthProviders\IAuthProvider.cs" />
     <Compile Include="AuthProviders\LoginState.cs" />
     <Compile Include="IGregClient.cs" />
+    <Compile Include="Requests\BanPackage.cs" />
     <Compile Include="Requests\Deprecate.cs" />
     <Compile Include="Requests\Downvote.cs" />
     <Compile Include="Requests\PackageReferenceRequest.cs" />

--- a/src/GregClient/Requests/BanPackage.cs
+++ b/src/GregClient/Requests/BanPackage.cs
@@ -4,16 +4,14 @@ namespace Greg.Requests
 {
     public class BanPackage : Request
     {
-        private enum Action { Ban, Unban }
+        public enum Action { Ban, Unban }
         private readonly Action banAction;
         private readonly string packageId;
 
-        public BanPackage(string packageId, bool banPackage)
+        public BanPackage(string packageId, BanPackage.Action banAction)
         {
-            // both endpoints require authentication by the user
-            this.ForceAuthentication = true;
             this.packageId = packageId;
-            this.banAction = banPackage ? Action.Ban : Action.Unban;
+            this.banAction = banAction;
         }
 
         public override string Path

--- a/src/GregClient/Requests/BanPackage.cs
+++ b/src/GregClient/Requests/BanPackage.cs
@@ -1,0 +1,37 @@
+﻿using RestSharp;
+
+namespace Greg.Requests
+{
+    public class BanPackage : Request
+    {
+        private enum Action { Ban, Unban }
+        private readonly Action banAction;
+        private readonly string packageId;
+
+        public BanPackage(string packageId, bool banPackage)
+        {
+            // both endpoints require authentication by the user
+            this.ForceAuthentication = true;
+            this.packageId = packageId;
+            this.banAction = banPackage ? Action.Ban : Action.Unban;
+        }
+
+        public override string Path
+        {
+            get
+            {
+                var root = banAction == Action.Ban ? "ban/" : "unban/";
+                return root + packageId;
+            }
+        }
+
+        public override Method HttpMethod
+        {
+            get { return Method.PUT; }
+        }
+
+        internal override void Build(ref RestRequest request)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This pull request implements client-side API that works with [its REST counterparts](https://github.com/DynamoDS/GReg/pull/2). More details can be found on that pull request.

NOTE: We may or may not require this, it all depends on how we expose the functionality of banning a package. This should only be allowed for internal teammates, so we may end up exposing a web-page that allows banning/unbanning a package.

### Declarations

Check these if you believe they are true

- [ ] The code base is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files

### Reviewers

@pboyer, please have a look. If you have an idea of how we expose this banning functionality to only internal teammates (e.g. some site served only on ADS domain), then I'd love to hear from you. Thanks!