### PR TITLE
Catch whitelist 404 and return null package response.

### DIFF
--- a/src/GregClient/GregClient.cs
+++ b/src/GregClient/GregClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using Greg.Requests;
 using Greg.Responses;
 using RestSharp;
@@ -45,9 +46,22 @@ namespace Greg
             return Execute(m).Deserialize();
         }
 
+        /// <summary>
+        /// Execute the request and deserialize the content.
+        /// </summary>
+        /// <typeparam name="T">The Type of content</typeparam>
+        /// <param name="m">The request.</param>
+        /// <returns>A <see cref="ResponseWithContent{T}"/> or null if there was an error
+        /// in executing the message.</returns>
         public ResponseWithContentBody<T> ExecuteAndDeserializeWithContent<T>(Request m)
         {
             var response = this.ExecuteInternal(m);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
             return new ResponseWithContent<T>(response).DeserializeWithContent();
         }
 

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -115,7 +115,13 @@ namespace GregClientSandbox
 
             if (pkgResponse == null)
             {
-                Console.WriteLine("The package response is null.");
+                Console.WriteLine("There was an error with the whitelist request.");
+                return;
+            }
+
+            if (pkgResponse.content == null)
+            {
+                Console.WriteLine("The package response content was null.");
                 return;
             }
 

--- a/src/GregClientSandbox/Program.cs
+++ b/src/GregClientSandbox/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Greg;
 using Greg.Requests;
 using Greg.Responses;
@@ -21,8 +22,9 @@ namespace GregClientSandbox
         /// A GregClient specifying the local host. The alternate IP provided is for 
         /// production Reach. 
         /// </summary>
-        //private static GregClient pmc = new GregClient(provider, "http://107.20.146.184/");
-        private static GregClient pmc = new GregClient(provider, "http://localhost:8080/");
+        private static GregClient pmc = new GregClient(provider, "http://107.20.146.184/");
+        //private static GregClient pmc = new GregClient(provider, "http://localhost:8080/");
+        //private static GregClient pmc = new GregClient(provider, "http://dynamopackages.com/");
 
         private static string DownloadPackageByIdTest()
         {
@@ -111,8 +113,19 @@ namespace GregClientSandbox
             var nv = WhitelistHeaderCollectionDownload.All();
             var pkgResponse = pmc.ExecuteAndDeserializeWithContent<List<PackageHeader>>(nv);
 
+            if (pkgResponse == null)
+            {
+                Console.WriteLine("The package response is null.");
+                return;
+            }
+
             Console.WriteLine(pkgResponse.message);
-            Console.WriteLine(pkgResponse.content);
+
+            var libs = pkgResponse.content.SelectMany(p => p.versions.Last().node_libraries).Distinct();
+            foreach (var lib in libs)
+            {
+                Console.WriteLine(lib);
+            }
         }
         
         static void Main(string[] args)


### PR DESCRIPTION
This PR adds error handling to the `ExecuteAndDeserializeWithContent<T>(...)` method. If the request returns a 404 (Not Found), this method will now return null. Previously, this method returned the response to the parser which then failed because the response's content was empty. The documentation for the method has been updated to indicate that the method will now return null if there was an error in executing the message.

When this PR is merged, a new GregClient NuGet will be generated an uploaded to nuget.org. That NuGet will then be referenced in Reach, and a PR will be issued for Reach.

PTAL: 
@mjkkirschner 

FYI:
@sharadkjaiswal 